### PR TITLE
Improve createGroup error reporting

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1586,7 +1586,10 @@ class Client extends EventEmitter {
                     participantWids
                 );
             } catch (err) {
-                return 'CreateGroupError: An unknown error occupied while creating a group';
+                const errorMsg =
+                    'CreateGroupError: ' +
+                    ((err && (err.message || err.text)) ? (err.message || err.text) : 'An unknown error occupied while creating a group');
+                return errorMsg;
             }
 
             for (const participant of createGroupResult.participants) {


### PR DESCRIPTION
## Summary
- return the original error message from the browser when `createGroup` fails

## Testing
- `npm test` *(fails: The WWEBJS_TEST_REMOTE_ID environment variable has not been set)*

------
https://chatgpt.com/codex/tasks/task_e_6886b3083cbc832ca5f311df35137a09