### PR TITLE
Add helper to get GroupUtils createGroup source

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,6 +138,9 @@ declare namespace WAWebJS {
         /** Returns the version of WhatsApp Web currently being run */
         getWWebVersion(): Promise<string>
 
+        /** Returns the raw source of WhatsApp Web's internal GroupUtils.createGroup implementation */
+        getCreateGroupSource(): Promise<string | null>
+
         /** Sets up events and requirements, kicks off authentication request */
         initialize(): Promise<void>
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -822,6 +822,16 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Returns the raw source of WhatsApp Web's internal GroupUtils.createGroup implementation
+     * @returns {Promise<string|null>} The function source as a string or null if unavailable
+     */
+    async getCreateGroupSource() {
+        return await this.pupPage.evaluate(() => {
+            return window.Store?.GroupUtils?.createGroup?.toString() || null;
+        });
+    }
+
+    /**
      * Mark as seen for the Chat
      *  @param {string} chatId
      *  @returns {Promise<boolean>} result


### PR DESCRIPTION
## Summary
- expose a helper to obtain WhatsApp Web's internal `GroupUtils.createGroup` source code
- update TypeScript definitions

## Testing
- `npm test` *(fails: The WWEBJS_TEST_REMOTE_ID environment variable has not been set)*

------
https://chatgpt.com/codex/tasks/task_e_6886c38e39d0832c9bc7ccd21808aeec